### PR TITLE
Correct the number of microsteps for TMC drivers

### DIFF
--- a/src/configs/accessories/use-32-microsteps
+++ b/src/configs/accessories/use-32-microsteps
@@ -1,0 +1,20 @@
+opt_set DEFAULT_AXIS_STEPS_PER_UNIT "{ 200, 200, 800, 200 }"
+
+# NB! The values below will only have any effect if the board is fitted with programmable drivers
+
+opt_set X_MICROSTEPS "32"
+opt_set Y_MICROSTEPS "32"
+opt_set Z_MICROSTEPS "32"
+opt_set X2_MICROSTEPS "32"
+opt_set Y2_MICROSTEPS "32"
+opt_set Z2_MICROSTEPS "32"
+opt_set E0_MICROSTEPS "32"
+opt_set E1_MICROSTEPS "32"
+opt_set E2_MICROSTEPS "32"
+opt_set E3_MICROSTEPS "32"
+opt_set E4_MICROSTEPS "32"
+opt_set E5_MICROSTEPS "32"
+opt_set E6_MICROSTEPS "32"
+opt_set E7_MICROSTEPS "32"
+
+echo "- Configured to use 32 microsteps" >> README.md

--- a/src/configs/boards/ramps
+++ b/src/configs/boards/ramps
@@ -5,5 +5,6 @@ pushd Marlin/src/HAL
 rm -rf DUE ESP32 LINUX LPC1768 SAMD51 STM* TEENSY*
 popd
 
-opt_set DEFAULT_AXIS_STEPS_PER_UNIT "{ 200, 200, 800, 200 }"
+. $CFGDIR/accessories/use-32-microsteps
 
+echo "- Configured for RAMPS" >> README.md

--- a/src/configs/boards/skr_1p3
+++ b/src/configs/boards/skr_1p3
@@ -3,7 +3,7 @@ opt_set MOTHERBOARD BOARD_BTT_SKR_V1_3
 opt_set SERIAL_PORT "-1"
 opt_set SERIAL_PORT_2 0
 
-opt_set DEFAULT_AXIS_STEPS_PER_UNIT "{ 200, 200, 800, 200 }"
+. $CFGDIR/accessories/use-32-microsteps
 
 pushd Marlin/src/HAL
 rm -rf AVR DUE ESP32 LINUX SAMD51 STM* TEENSY*


### PR DESCRIPTION
- Invert motion direction for SKR 1.3 and TMC2209 combination
- Disable Z-axis timeout for Lowrider configurations
- Correct the number of microsteps for TMC drivers