### PR TITLE
Testing out removing the extra HAL directories.

### DIFF
--- a/src/configs/boards/mini-rambo
+++ b/src/configs/boards/mini-rambo
@@ -3,6 +3,10 @@ opt_set DEFAULT_AXIS_STEPS_PER_UNIT "{ 100, 100, 400, 837 }"
 opt_set PWM_MOTOR_CURRENT "{ 900, 900, 900 }"
 opt_set E0_AUTO_FAN_PIN "6"
 
+pushd Marlin/src/HAL
+rm -rf DUE ESP32 LINUX LPC1768 SAMD51 STM* TEENSY*
+popd
+
 # Write some useful tidbits to the readme.
 echo "- Configured for MiniRambo" >> README.md
 

--- a/src/configs/boards/rambo
+++ b/src/configs/boards/rambo
@@ -2,6 +2,10 @@ opt_set MOTHERBOARD "BOARD_RAMBO"
 opt_set DEFAULT_AXIS_STEPS_PER_UNIT "{ 100, 100, 400, 100 }"
 opt_set DIGIPOT_MOTOR_CURRENT "{ 138, 138, 138, 138, 138 }"
 
+pushd Marlin/src/HAL
+rm -rf DUE ESP32 LINUX LPC1768 SAMD51 STM* TEENSY*
+popd
+
 # Write some useful tidbits to the readme.
 echo "- Configured for Rambo" >> README.md
 

--- a/src/configs/boards/ramps
+++ b/src/configs/boards/ramps
@@ -1,5 +1,9 @@
 
 # MOTHERBOARD is set to ramps by default.
 
+pushd Marlin/src/HAL
+rm -rf DUE ESP32 LINUX LPC1768 SAMD51 STM* TEENSY*
+popd
+
 opt_set DEFAULT_AXIS_STEPS_PER_UNIT "{ 200, 200, 800, 200 }"
 

--- a/src/configs/boards/skr_1p3
+++ b/src/configs/boards/skr_1p3
@@ -5,6 +5,10 @@ opt_set SERIAL_PORT_2 0
 
 opt_set DEFAULT_AXIS_STEPS_PER_UNIT "{ 200, 200, 800, 200 }"
 
+pushd Marlin/src/HAL
+rm -rf AVR DUE ESP32 LINUX SAMD51 STM* TEENSY*
+popd
+
 # Write some useful tidbits to the readme.
 echo "- Configured for Skr v1.3" >> README.md
 

--- a/src/configs/boards/skr_pro
+++ b/src/configs/boards/skr_pro
@@ -13,7 +13,7 @@ opt_set SERIAL_PORT_2 -1
 opt_set DEFAULT_AXIS_STEPS_PER_UNIT "{ 100, 100, 400, 100 }"
 
 pushd Marlin/src/HAL
-rm -rf AVR DUE ESP32 LINUX SAMD51 STM* TEENSY*
+rm -rf AVR DUE ESP32 LINUX LPC1768 SAMD51 TEENSY*
 popd
 
 # Write some useful tidbits to the readme.

--- a/src/configs/boards/skr_pro
+++ b/src/configs/boards/skr_pro
@@ -12,6 +12,10 @@ opt_set SERIAL_PORT_2 -1
 
 opt_set DEFAULT_AXIS_STEPS_PER_UNIT "{ 100, 100, 400, 100 }"
 
+pushd Marlin/src/HAL
+rm -rf AVR DUE ESP32 LINUX SAMD51 STM* TEENSY*
+popd
+
 # Write some useful tidbits to the readme.
 echo "- Configured for Skr Pro v1.2" >> README.md
 


### PR DESCRIPTION
This is me trying to delete HAL folders that get ignored in platformio, but are left in the arduino builds, which breaks the builds in windows.

I'm not sure I have the HAL folders right, especially for the skr pro.