### PR TITLE
Remove this from the cnc config, since it is in the base now

### DIFF
--- a/src/configs/common/cnc-config
+++ b/src/configs/common/cnc-config
@@ -32,7 +32,6 @@ opt_set USER_GCODE_3 "\"G28 X Y\""
 
 opt_enable \
     EEPROM_SETTINGS \
-    EEPROM_AUTO_INIT \
     CLASSIC_JERK \
     S_CURVE_ACCELERATION \
     ARC_SUPPORT \


### PR DESCRIPTION
This just removes this from the cnc config. So it isn't double set. I don't think there's a problem with double set, but this is cleaner.