### PR TITLE
Try putting the arduino build back in for the archim boards.

### DIFF
--- a/.github/workflows/archim.yml
+++ b/.github/workflows/archim.yml
@@ -80,6 +80,18 @@ jobs:
       run: |
         src/core/build-for-machine
 
+    - name: Build Arduino
+      uses: ArminJo/arduino-test-compile@v2
+      with:
+        sketch-names: Marlin.ino
+        # -fqbn in the first line of the arduino console log.
+        arduino-board-fqbn: ultimachine:sam:archim
+        # This is what you would put into the board manager url.
+        platform-url: https://raw.githubusercontent.com/ultimachine/ArduinoAddons/master/package_ultimachine_index.json
+        # Save the .hex/.bin/whatever file. It should end up in $HOME/Marlin/
+        set-build-path: true
+        required-libraries: TMCStepper
+
     - name: Zip up Marlin
       run: |
         src/core/zip-marlin


### PR DESCRIPTION
~~Don't merge this at least until it passes. I'm just trying to provoke a build.~~

This adds in a step for the archim boards to build in the arduino tool. Since 2.0.6.1 and something in bugfix has fixed these builds.

This is good to keep in here, even though we are already building with platform io. Because it shows that a user _should_ be able to build with arduino. I am also not confident that the archim boards are acting the right way in recent versions, and platformio may be part of the problem. IDK.