### PR TITLE
Test serial ports for TFT screen.

### DIFF
--- a/src/configs/boards/mini-rambo
+++ b/src/configs/boards/mini-rambo
@@ -7,6 +7,8 @@ pushd Marlin/src/HAL
 rm -rf DUE ESP32 LINUX LPC1768 SAMD51 STM* TEENSY*
 popd
 
+opt_set SERIAL_PORT_2 2
+
 # Write some useful tidbits to the readme.
 echo "- Configured for MiniRambo" >> README.md
 

--- a/src/configs/boards/rambo
+++ b/src/configs/boards/rambo
@@ -6,6 +6,8 @@ pushd Marlin/src/HAL
 rm -rf DUE ESP32 LINUX LPC1768 SAMD51 STM* TEENSY*
 popd
 
+opt_set SERIAL_PORT_2 1
+
 # Write some useful tidbits to the readme.
 echo "- Configured for Rambo" >> README.md
 


### PR DESCRIPTION
This enables the second serial ports on the mini rambo and the rambo.

Schematic for mini-rambo:
![minirambo](https://www.reprap.org/mediawiki/images/e/ef/MiniRambo1.3a-schematic-pg2.svg)

The P3 looks like it lines up nicely with the TFT connector. But I didn't look too closely.

Schematic for the rambo: https://github.com/ultimachine/RAMBo-1.4/blob/1.4/Project%20Outputs/Schematic%20Prints_RAMBo_1.4a.PDF (In the "Serial Expansion" on pg 2)

I don't have either of these boards, but if we enable these things, you can start offering the TFT screen with the rambo/minirambo boards. We will need to add some instructions for people to wire them up.

This is a new feature, not a hardening of the current version, so I'm happy postponing this.
