### PR TITLE
Sensorless homing base

### DIFF
--- a/src/configs/accessories/sensorless-homing
+++ b/src/configs/accessories/sensorless-homing
@@ -1,0 +1,25 @@
+opt_set SENSORLESS_HOMING
+
+# Move away from hard stops after homing to reduce the chance of prolonged stress on the machine
+opt_set HOMING_BACKOFF_POST_MM "{ 2, 2, 2 }"
+
+# Setting bump to zero is claimed to improve stallguard homing accuracy.
+# However in preliminary testing this was shown to be true only for Z-axis
+opt_set HOMING_BUMP_MM "{ 5, 5, 0 }"
+
+opt_enable IMPROVE_HOMING_RELIABILITY \
+	Z_STALL_SENSITIVITY \
+	Z2_STALL_SENSITIVITY
+
+# Disable incompatible defaults.
+# - TMC diag pin is often hardwired to Z- thus a probe can not be connected there
+# - Sensorless homing uses diag pins which are already defined in pins.h thus no need to customize
+opt_disable Z_MIN_PROBE_PIN \
+	Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN \
+	X2_USE_ENDSTOP \
+	Y2_USE_ENDSTOP \
+	Z2_USE_ENDSTOP
+
+opt_set Z_MIN_ENDSTOP_INVERTING "false"
+
+echo "- Configured for sensorless homing" >> README.md

--- a/src/configs/accessories/tmc2209
+++ b/src/configs/accessories/tmc2209
@@ -32,4 +32,11 @@ opt_disable \
     STEALTHCHOP_Z \
     STEALTHCHOP_E
 
+# Stall sensitivity values are driver specific.
+# These will only be used when sensorless homing is also enabled
+# TMC2209 sensitivity setting is 255..0, 0 being the most insentive
+opt_set X_STALL_SENSITIVITY "50"
+opt_set Y_STALL_SENSITIVITY "50"
+opt_set Z_STALL_SENSITIVITY "40"
+
 echo "- Configured for TMC2209" >> README.md


### PR DESCRIPTION
Re-creating due to repository move.

Supersedes #11  