### PR TITLE
Put the firmware name back to the basic firmware.bin

### DIFF
--- a/.github/workflows/archim.yml
+++ b/.github/workflows/archim.yml
@@ -101,7 +101,7 @@ jobs:
       with:
         name: ${{ matrix.machine }}-${{ matrix.branch }}
         path: |
-          firmware_*
+          firmware*
           Marlin_*.zip
 
     - name: Upload Marlin-${{ matrix.machine }}-${{ matrix.branch }}-src.zip to release

--- a/.github/workflows/rambo.yml
+++ b/.github/workflows/rambo.yml
@@ -104,7 +104,7 @@ jobs:
       with:
         name: ${{ matrix.machine }}-${{ matrix.branch }}
         path: |
-          firmware_*
+          firmware*
           Marlin_*.zip
 
     - name: Upload Marlin-${{ matrix.machine }}-${{ matrix.branch }}-src.zip to release

--- a/.github/workflows/ramps.yml
+++ b/.github/workflows/ramps.yml
@@ -98,7 +98,7 @@ jobs:
       with:
         name: ${{ matrix.machine }}-${{ matrix.branch }}
         path: |
-          firmware_*
+          firmware*
           Marlin_*.zip
 
     - name: Upload Marlin-${{ matrix.machine }}-${{ matrix.branch }}-src.zip to release

--- a/.github/workflows/skr1p3.yml
+++ b/.github/workflows/skr1p3.yml
@@ -92,7 +92,7 @@ jobs:
       with:
         name: ${{ matrix.machine }}-${{ matrix.branch }}
         path: |
-          firmware_*
+          firmware*
           Marlin_*.zip
 
     - name: Upload Marlin-${{ matrix.machine }}-${{ matrix.branch }}-src.zip to release

--- a/.github/workflows/skrpro.yml
+++ b/.github/workflows/skrpro.yml
@@ -89,7 +89,7 @@ jobs:
       with:
         name: ${{ matrix.machine }}-${{ matrix.branch }}
         path: |
-          firmware_*
+          firmware*
           Marlin_*.zip
 
     - name: Upload Marlin-${{ matrix.machine }}-${{ matrix.branch }}-src.zip to release

--- a/src/core/zip-marlin
+++ b/src/core/zip-marlin
@@ -39,7 +39,7 @@ short_name=$(basename "$MARLINDIR")
 zip -prq "Marlin_${CONFIG_NAME}_${MARLIN_VERSION}_${V1_VERSION}"-src.zip "$short_name"
 
 # It's ok if these fail
-mv firmware.bin "firmware_${CONFIG_NAME}_${MARLIN_VERSION}_${V1_VERSION}.bin" || echo "No bin file found"
-mv firmware.hex "firmware_${CONFIG_NAME}_${MARLIN_VERSION}_${V1_VERSION}.hex" || echo "No hex file found"
+mv firmware.bin "firmware.bin" || echo "No bin file found"
+mv firmware.hex "firmware.hex" || echo "No hex file found"
 
-zip -prq Marlin-Release.zip "Marlin_${CONFIG_NAME}_${MARLIN_VERSION}_${V1_VERSION}"-src.zip firmware_*
+zip -prq Marlin-Release.zip "Marlin_${CONFIG_NAME}_${MARLIN_VERSION}_${V1_VERSION}"-src.zip firmware\.*

--- a/src/core/zip-marlin
+++ b/src/core/zip-marlin
@@ -38,4 +38,4 @@ cd "$MARLINDIR"/..
 short_name=$(basename "$MARLINDIR")
 zip -prq "Marlin_${CONFIG_NAME}_${MARLIN_VERSION}_${V1_VERSION}"-src.zip "$short_name"
 
-zip -prq Marlin-Release.zip "Marlin_${CONFIG_NAME}_${MARLIN_VERSION}_${V1_VERSION}"-src.zip firmware*
+zip -pr Marlin-Release.zip "Marlin_${CONFIG_NAME}_${MARLIN_VERSION}_${V1_VERSION}"-src.zip firmware*

--- a/src/core/zip-marlin
+++ b/src/core/zip-marlin
@@ -38,8 +38,4 @@ cd "$MARLINDIR"/..
 short_name=$(basename "$MARLINDIR")
 zip -prq "Marlin_${CONFIG_NAME}_${MARLIN_VERSION}_${V1_VERSION}"-src.zip "$short_name"
 
-# It's ok if these fail
-mv firmware.bin "firmware.bin" || echo "No bin file found"
-mv firmware.hex "firmware.hex" || echo "No hex file found"
-
-zip -prq Marlin-Release.zip "Marlin_${CONFIG_NAME}_${MARLIN_VERSION}_${V1_VERSION}"-src.zip firmware\.*
+zip -prq Marlin-Release.zip "Marlin_${CONFIG_NAME}_${MARLIN_VERSION}_${V1_VERSION}"-src.zip firmware*


### PR DESCRIPTION
This sets the firmware file inside the zip back to just firmware.bin or firmware.hex. I will download a .zip and make sure it didn't grab any extra things named firmware.