### PR TITLE
Enable M3 inline laser command

### DIFF
--- a/src/configs/V1CNC_Rambo
+++ b/src/configs/V1CNC_Rambo
@@ -9,5 +9,6 @@ $CFGDIR/common/cnc-config
 $CFGDIR/boards/rambo
 $CFGDIR/accessories/reprap_discount_full_graphic_lcd
 $CFGDIR/accessories/no-dual-endstops
+$CFGDIR/accessories/laser-32bit
 
 export PLATFORMIO_ENV=rambo

--- a/src/configs/V1CNC_Rambo_Dual
+++ b/src/configs/V1CNC_Rambo_Dual
@@ -11,6 +11,7 @@ $CFGDIR/common/cnc-config
 $CFGDIR/boards/rambo
 $CFGDIR/accessories/reprap_discount_full_graphic_lcd
 $CFGDIR/accessories/dual-drivers-on-xy
+$CFGDIR/accessories/laser-32bit
 
 opt_enable \
     X2_DRIVER_TYPE \

--- a/src/configs/V1CNC_Rambo_DualLR
+++ b/src/configs/V1CNC_Rambo_DualLR
@@ -11,6 +11,7 @@ $CFGDIR/common/cnc-config
 $CFGDIR/boards/rambo
 $CFGDIR/accessories/reprap_discount_full_graphic_lcd
 $CFGDIR/accessories/dual-drivers-on-yz
+$CFGDIR/accessories/laser-32bit
 
 opt_enable \
     X2_DRIVER_TYPE \


### PR DESCRIPTION
Enable M3 inline laser commands, pin is already defined. Currently there are no differences between 32 bit and 8 bit lasers. If Ramping is added in the future this will need to get split up.