### PR TITLE
Disable the archim arduino build.

### DIFF
--- a/.github/workflows/archim.yml
+++ b/.github/workflows/archim.yml
@@ -80,18 +80,6 @@ jobs:
       run: |
         src/core/build-for-machine
 
-        #- name: Build Arduino
-        #  uses: ArminJo/arduino-test-compile@v2
-        #  with:
-        #    sketch-names: Marlin.ino
-        #    # -fqbn in the first line of the arduino console log.
-        #    arduino-board-fqbn: ultimachine:sam:archim
-        #    # This is what you would put into the board manager url.
-        #    platform-url: https://raw.githubusercontent.com/ultimachine/ArduinoAddons/master/package_ultimachine_index.json
-        #    # Save the .hex/.bin/whatever file. It should end up in $HOME/Marlin/
-        #    set-build-path: true
-        #    required-libraries: TMCStepper
-
     - name: Zip up Marlin
       run: |
         src/core/zip-marlin

--- a/.github/workflows/archim.yml
+++ b/.github/workflows/archim.yml
@@ -80,17 +80,17 @@ jobs:
       run: |
         src/core/build-for-machine
 
-    - name: Build Arduino
-      uses: ArminJo/arduino-test-compile@v2
-      with:
-        sketch-names: Marlin.ino
-        # -fqbn in the first line of the arduino console log.
-        arduino-board-fqbn: ultimachine:sam:archim
-        # This is what you would put into the board manager url.
-        platform-url: https://raw.githubusercontent.com/ultimachine/ArduinoAddons/master/package_ultimachine_index.json
-        # Save the .hex/.bin/whatever file. It should end up in $HOME/Marlin/
-        set-build-path: true
-        required-libraries: TMCStepper
+        #- name: Build Arduino
+        #  uses: ArminJo/arduino-test-compile@v2
+        #  with:
+        #    sketch-names: Marlin.ino
+        #    # -fqbn in the first line of the arduino console log.
+        #    arduino-board-fqbn: ultimachine:sam:archim
+        #    # This is what you would put into the board manager url.
+        #    platform-url: https://raw.githubusercontent.com/ultimachine/ArduinoAddons/master/package_ultimachine_index.json
+        #    # Save the .hex/.bin/whatever file. It should end up in $HOME/Marlin/
+        #    set-build-path: true
+        #    required-libraries: TMCStepper
 
     - name: Zip up Marlin
       run: |


### PR DESCRIPTION
This disables the archim arduino builds. I am just about ready to disable the archims all together. I am not sure if publishing the platformio builds is a good idea, because my memory is that the platformio build or flash didn't work as well as the arduino one did.