### PR TITLE
remove incorrect readme note

### DIFF
--- a/src/configs/common/cnc-config
+++ b/src/configs/common/cnc-config
@@ -49,6 +49,5 @@ opt_disable \
 
 # Write some useful tidbits to the readme.
 echo "- Configured for CNC" >> README.md
-echo "- EXTRUDERS = 0" >> README.md
 echo "- Custom LCD commands" >> README.md
 


### PR DESCRIPTION
The extruders are set to zero in the dual driver files:

https://github.com/V1EngineeringInc/MarlinBuilder/blob/main/src/configs/accessories/dual-drivers-on-xy#L1

This fixes #82 