### PR TITLE
Mini rambo laser fix and ESP3D long file name support

### DIFF
--- a/src/configs/V1CNC_MiniRambo
+++ b/src/configs/V1CNC_MiniRambo
@@ -11,6 +11,5 @@ $CFGDIR/common/cnc-config
 $CFGDIR/boards/mini-rambo
 $CFGDIR/accessories/reprap_discount_full_graphic_lcd
 $CFGDIR/accessories/no-dual-endstops
-$CFGDIR/accessories/laser
 
 export PLATFORMIO_ENV=rambo

--- a/src/configs/common/v1-base-config
+++ b/src/configs/common/v1-base-config
@@ -11,6 +11,8 @@ echo "#define SHORT_BUILD_VERSION \"${V1_VERSION} ${MARLIN_VERSION}\"" >> Marlin
 
 opt_enable \
     DIRECT_PIN_CONTROL \
+    LONG_FILENAME_HOST_SUPPORT \
+    LONG_FILENAME_WRITE_SUPPORT \
     EEPROM_AUTO_INIT
 
 opt_disable \


### PR DESCRIPTION
mini LCD and Laser pins are conflicting

ESP3D needs long filenames enabled.