### PR TITLE
SQUARE_WAVE_STEPPING is now called EDGE_STEPPING

### DIFF
--- a/src/configs/accessories/tmc2209
+++ b/src/configs/accessories/tmc2209
@@ -11,7 +11,7 @@ opt_set Z_CURRENT 900
 
 opt_enable \
     MONITOR_DRIVER_STATUS \
-    SQUARE_WAVE_STEPPING \
+    EDGE_STEPPING \
     TMC_DEBUG
 
 opt_disable \


### PR DESCRIPTION
See [this change](https://github.com/MarlinFirmware/Marlin/blob/0138aff890c458f78b68aa21753bcf5d6e5bf488/Marlin/src/inc/Changes.h#L627C39-L627C52), compilation fails without this change on my end (with octopus v1.1 board).