### PR TITLE
Addressed build error for the current bugfix-2.1.x branch

### DIFF
--- a/.github/workflows/skrpro.yml
+++ b/.github/workflows/skrpro.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:
   pull_request:
     branches:
     - main
@@ -37,6 +38,7 @@ jobs:
         branch: ${{ fromJson(
           github.event_name == 'schedule' && '["bugfix-2.1.x"]' ||
           github.event_name == 'pull_request' && '["bugfix-2.1.x", "2.1.2"]' ||
+          github.event_name == 'workflow_dispatch' && '["bugfix-2.1.x"]' ||
           '["2.1.2"]') }}
         machine:
         - V13DP_SkrPro_2209

--- a/src/configs/V13DP_SkrPro_2209
+++ b/src/configs/V13DP_SkrPro_2209
@@ -19,4 +19,10 @@ opt_set Y_DRIVER_TYPE  "TMC2209"
 opt_set Z_DRIVER_TYPE  "TMC2209"
 opt_set E0_DRIVER_TYPE  "TMC2209"
 
-export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+if [ ${MARLIN_CONFIG_VERSION} -gt 02010205 ]; then
+  export PLATFORMIO_ENV=BTT_SKR_PRO
+  echo "Marlin > 2.1.2.5"
+else
+  export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+  echo "Marlin <= 2.1.2.5"
+fi

--- a/src/configs/V13RP_SkrPro_2209
+++ b/src/configs/V13RP_SkrPro_2209
@@ -37,4 +37,11 @@ opt_enable \
     STEALTHCHOP_XY \
     STEALTHCHOP_Z \
     STEALTHCHOP_E
-export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+
+if [ ${MARLIN_CONFIG_VERSION} -gt 02010205 ]; then
+  export PLATFORMIO_ENV=BTT_SKR_PRO
+  echo "Marlin > 2.1.2.5"
+else
+  export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+  echo "Marlin <= 2.1.2.5"
+fi

--- a/src/configs/V13RP_V4_SkrPro_2209
+++ b/src/configs/V13RP_V4_SkrPro_2209
@@ -37,4 +37,11 @@ opt_enable \
     STEALTHCHOP_XY \
     STEALTHCHOP_Z \
     STEALTHCHOP_E
-export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+    
+if [ ${MARLIN_CONFIG_VERSION} -gt 02010205 ]; then
+  export PLATFORMIO_ENV=BTT_SKR_PRO
+  echo "Marlin > 2.1.2.5"
+else
+  export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+  echo "Marlin <= 2.1.2.5"
+fi

--- a/src/configs/V1CNC_SkrPro_2209
+++ b/src/configs/V1CNC_SkrPro_2209
@@ -14,11 +14,17 @@ $CFGDIR/accessories/TFT35_e3_v3_CNC
 $CFGDIR/accessories/no-dual-endstops
 $CFGDIR/accessories/laser
 
-opt_add SPINDLE_LASER_PWM_PIN PC9
-opt_add SPINDLE_LASER_ENA_PIN PB0 // Heater2
+opt_set SPINDLE_LASER_PWM_PIN PC9
+opt_set SPINDLE_LASER_ENA_PIN PB0 # Heater2
 
 opt_set X_DRIVER_TYPE  "TMC2209"
 opt_set Y_DRIVER_TYPE  "TMC2209"
 opt_set Z_DRIVER_TYPE  "TMC2209"
 
-export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+if [ ${MARLIN_CONFIG_VERSION} -gt 02010205 ]; then
+  export PLATFORMIO_ENV=BTT_SKR_PRO
+  echo "Marlin > 2.1.2.5"
+else
+  export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+  echo "Marlin <= 2.1.2.5"
+fi

--- a/src/configs/V1CNC_SkrPro_DualLR_2209
+++ b/src/configs/V1CNC_SkrPro_DualLR_2209
@@ -15,8 +15,8 @@ $CFGDIR/accessories/dual-drivers-on-yz
 $CFGDIR/boards/skr_pro_dual
 $CFGDIR/accessories/laser
 
-opt_add SPINDLE_LASER_PWM_PIN PC9
-opt_add SPINDLE_LASER_ENA_PIN PB0 // Heater2
+opt_set SPINDLE_LASER_PWM_PIN PC9
+opt_set SPINDLE_LASER_ENA_PIN PB0 # Heater2
 
 
 opt_set X_DRIVER_TYPE  "TMC2209"
@@ -32,4 +32,10 @@ opt_disable \
     E0_DRIVER_TYPE
 
 
-export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+if [ ${MARLIN_CONFIG_VERSION} -gt 02010205 ]; then
+  export PLATFORMIO_ENV=BTT_SKR_PRO
+  echo "Marlin > 2.1.2.5"
+else
+  export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+  echo "Marlin <= 2.1.2.5"
+fi

--- a/src/configs/V1CNC_SkrPro_Dual_2209
+++ b/src/configs/V1CNC_SkrPro_Dual_2209
@@ -15,8 +15,8 @@ $CFGDIR/accessories/dual-drivers-on-xy
 $CFGDIR/boards/skr_pro_dual
 $CFGDIR/accessories/laser
 
-opt_add SPINDLE_LASER_PWM_PIN PC9
-opt_add SPINDLE_LASER_ENA_PIN PB0 // Heater2
+opt_set SPINDLE_LASER_PWM_PIN PC9
+opt_set SPINDLE_LASER_ENA_PIN PB0 # Heater2
 
 
 opt_set X_DRIVER_TYPE  "TMC2209"
@@ -31,4 +31,10 @@ opt_set Y2_CURRENT 900
 opt_disable \
     E0_DRIVER_TYPE
 
-export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+if [ ${MARLIN_CONFIG_VERSION} -gt 02010205 ]; then
+  export PLATFORMIO_ENV=BTT_SKR_PRO
+  echo "Marlin > 2.1.2.5"
+else
+  export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+  echo "Marlin <= 2.1.2.5"
+fi

--- a/src/configs/V1ZXY_SkrPro_2209
+++ b/src/configs/V1ZXY_SkrPro_2209
@@ -18,4 +18,10 @@ opt_set Y_DRIVER_TYPE  "TMC2209"
 opt_set Z_DRIVER_TYPE  "TMC2209"
 opt_set E0_DRIVER_TYPE  "TMC2209"
 
-export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+if [ ${MARLIN_CONFIG_VERSION} -gt 02010205 ]; then
+  export PLATFORMIO_ENV=BTT_SKR_PRO
+  echo "Marlin > 2.1.2.5"
+else
+  export PLATFORMIO_ENV=BIGTREE_SKR_PRO
+  echo "Marlin <= 2.1.2.5"
+fi

--- a/src/configs/accessories/TFT35_e3_v3_CNC
+++ b/src/configs/accessories/TFT35_e3_v3_CNC
@@ -14,7 +14,7 @@ opt_enable \
 opt_set SERIAL_FLOAT_PRECISION 4
 opt_set LCD_TIMEOUT_TO_STATUS "180000"
 
-opt_add SPINDLE_LASER_ENA_PIN PB0   // Heater2
-opt_add SPINDLE_LASER_PWM_PIN PC9
+opt_set SPINDLE_LASER_ENA_PIN PB0 # Heater2
+opt_set SPINDLE_LASER_PWM_PIN PC9
 
 echo "- Configured for TFT35 E3 V3" >> README.md

--- a/src/configs/accessories/laser
+++ b/src/configs/accessories/laser
@@ -1,6 +1,11 @@
 opt_set SPINDLE_LASER_ACTIVE_STATE    HIGH
 opt_set SPEED_POWER_STARTUP 15
 
+# Required when using LASER_FEATURE since
+# https://github.com/MarlinFirmware/Marlin/commit/43d9d1ce1bc708f178612da0baa972c2f8fbe712
+# (Missing in sanity check)
+opt_set CUTTER_POWER_MAX 100
+
 opt_enable \
     LASER_FEATURE \
     LASER_POWER_SYNC \

--- a/src/configs/common/3dp-repeat-config
+++ b/src/configs/common/3dp-repeat-config
@@ -33,6 +33,9 @@ opt_set Y_BED_SIZE 205
 opt_set X_MIN_POS -23
 opt_set Y_MIN_POS -3
 opt_set Z_MAX_POS 223
+opt_set Z2_STOP_PIN Z_MAX_PIN
+opt_set Z3_STOP_PIN Z_MAX_PIN
+
 
 opt_set MESH_TEST_NOZZLE_SIZE    0.5
 opt_set MESH_TEST_LAYER_HEIGHT   0.35

--- a/src/configs/common/3dp-repeat-config
+++ b/src/configs/common/3dp-repeat-config
@@ -33,8 +33,8 @@ opt_set Y_BED_SIZE 205
 opt_set X_MIN_POS -23
 opt_set Y_MIN_POS -3
 opt_set Z_MAX_POS 223
-opt_set Z2_STOP_PIN Z_MAX_PIN
-opt_set Z3_STOP_PIN Z_MAX_PIN
+opt_set Z2_STOP_PIN PE10
+opt_set Z3_STOP_PIN PG5
 
 
 opt_set MESH_TEST_NOZZLE_SIZE    0.5

--- a/src/configs/common/3dp-repeat-config
+++ b/src/configs/common/3dp-repeat-config
@@ -33,8 +33,8 @@ opt_set Y_BED_SIZE 205
 opt_set X_MIN_POS -23
 opt_set Y_MIN_POS -3
 opt_set Z_MAX_POS 223
-opt_set Z2_STOP_PIN PE10
-opt_set Z3_STOP_PIN PG5
+opt_set Z2_STOP_PIN PE10 # E1 endstop
+opt_set Z3_STOP_PIN Z_MIN_PIN
 
 
 opt_set MESH_TEST_NOZZLE_SIZE    0.5


### PR DESCRIPTION
Now the different machine configs should build with the current bugfix-2.1.x branch and also still work with the 2.1.2-tag.